### PR TITLE
Fix: Gatsby cannot load SVGs in Windows environment

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -42,7 +42,7 @@ module.exports = {
       resolve: 'gatsby-plugin-react-svg',
       options: {
         rule: {
-          include: /images\/.*\.svg/
+          include: /images(\/|\\).*\.svg/
         }
       }
     },


### PR DESCRIPTION
Fix: Gatsby cannot load SVG in Windows environment